### PR TITLE
Add missing os import

### DIFF
--- a/scapy_ssl_tls/ssl_tls.py
+++ b/scapy_ssl_tls/ssl_tls.py
@@ -2,6 +2,8 @@
 # -*- coding: UTF-8 -*-
 # Author : <github.com/tintinweb/scapy-ssl_tls>
 
+import os
+
 from scapy.packet import bind_layers, Packet, Raw
 from scapy.fields import *
 from scapy.layers.inet import TCP, UDP


### PR DESCRIPTION
Up to now `os` module was used from `scapy` instead direct import. In recent versions of `scapy` `os` module was removed from their scope and this in a result exposed missing import in `scapy_ssl_tls`.